### PR TITLE
Add suave-geth customization

### DIFF
--- a/.github/workflows/publish-docker-image-every-push.yml
+++ b/.github/workflows/publish-docker-image-every-push.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - suave
 env:
   OTP_VERSION: '25.2.1'
   ELIXIR_VERSION: '1.14.3'
@@ -21,10 +22,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
@@ -53,9 +54,10 @@ jobs:
           context: .
           file: ./docker/Dockerfile
           push: true
-          cache-from: type=registry,ref=blockscout/blockscout:buildcache
-          cache-to: type=registry,ref=blockscout/blockscout:buildcache,mode=max
-          tags: blockscout/blockscout:master, blockscout/blockscout:${{ env.RELEASE_VERSION }}.commit.${{ env.SHORT_SHA }}
+          tags: adrienmo/blockscout:suave
+          platforms: |
+            linux/arm64
+            linux/amd64
           build-args: |
             CACHE_EXCHANGE_RATES_PERIOD=
             API_V1_READ_METHODS_DISABLED=false
@@ -71,54 +73,4 @@ jobs:
             CACHE_ADDRESS_WITH_BALANCES_UPDATE_INTERVAL=
             BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
-
-      - name: Build and push Docker image for frontend
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          file: ./docker/Dockerfile
-          push: true
-          cache-from: type=registry,ref=blockscout/blockscout:buildcache
-          tags: blockscout/blockscout:frontend-main
-          build-args: |
-            CACHE_EXCHANGE_RATES_PERIOD=
-            API_V1_READ_METHODS_DISABLED=false
-            DISABLE_WEBAPP=false
-            API_V1_WRITE_METHODS_DISABLED=false
-            CACHE_TOTAL_GAS_USAGE_COUNTER_ENABLED=
-            ADMIN_PANEL_ENABLED=false
-            CACHE_ADDRESS_WITH_BALANCES_UPDATE_INTERVAL=
-            SESSION_COOKIE_DOMAIN=k8s-dev.blockscout.com
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
-            RELEASE_VERSION=${{ env.RELEASE_VERSION }}
-  deploy_e2e:
-    needs: push_to_registry
-    runs-on: ubuntu-latest
-    permissions: write-all
-    steps:
-      - name: Get Vault credentials
-        id: retrieve-vault-secrets
-        uses: hashicorp/vault-action@v2.4.1
-        with:
-          url: https://vault.k8s.blockscout.com
-          role: ci-dev
-          path: github-jwt
-          method: jwt
-          tlsSkipVerify: false
-          exportToken: true
-          secrets: |
-            ci/data/dev/github token | WORKFLOW_TRIGGER_TOKEN ;
-      - name: Trigger deploy
-        uses: convictional/trigger-workflow-and-wait@v1.6.1
-        with:
-          owner: blockscout
-          repo: deployment-values
-          github_token: ${{env.WORKFLOW_TRIGGER_TOKEN}}
-          workflow_file_name: deploy_blockscout.yaml
-          ref: main
-          wait_interval: 30
-          client_payload: '{ "instance": "dev", "globalEnv": "e2e"}'
-  test:
-    needs: deploy_e2e
-    uses: blockscout/blockscout-ci-cd/.github/workflows/e2e_new.yaml@master
-    secrets: inherit
+            ERL_FLAGS=+JPperf true

--- a/apps/block_scout_web/assets/package-lock.json
+++ b/apps/block_scout_web/assets/package-lock.json
@@ -101,10 +101,11 @@
       }
     },
     "../../../deps/phoenix": {
-      "version": "0.0.1"
+      "version": "1.5.14",
+      "license": "MIT"
     },
     "../../../deps/phoenix_html": {
-      "version": "0.0.1"
+      "version": "3.0.4"
     },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
@@ -7,7 +7,7 @@
 <% base_fee_per_gas = if block, do: block.base_fee_per_gas, else: nil %>
 <% max_priority_fee_per_gas = @transaction.max_priority_fee_per_gas %>
 <% max_fee_per_gas = @transaction.max_fee_per_gas %>
-<% burned_fee = 
+<% burned_fee =
   if !is_nil(max_fee_per_gas) and !is_nil(@transaction.gas_used) and !is_nil(base_fee_per_gas) do
     if Decimal.compare(max_fee_per_gas.value, 0) == :eq do
       %Wei{value: Decimal.new(0)}
@@ -122,7 +122,7 @@
                     <% true -> %>
                       <%= render BlockScoutWeb.FormView, "_tag.html", text: formatted_status, additional_classes: ["success", "large"] %></span>
                   <% end %>
-                
+
                 <%= if confirmations > 0 do %>
                   <span class="bs-label large ml-2 confirmations-label"><%= gettext "Confirmed by " %><span data-selector="block-confirmations"><%= confirmations %></span><%= " " <> confirmations_ds_name(confirmations) %></span>
                 <% end %>
@@ -429,7 +429,7 @@
               </dt>
               <dd class="col-sm-9 col-lg-10"> <%= format_wei_value(priority_fee, :ether) %> </dd>
             </dl>
-          <% end %> 
+          <% end %>
            <%= if !is_nil(burned_fee) do %>
             <dl class="row">
               <dt class="col-sm-3 col-lg-2 text-muted">
@@ -519,6 +519,38 @@
                 </div>
               </dd>
             </dl>
+          <% end %>
+          <%= unless is_nil(IO.inspect(@transaction).confidential_compute_result) do %>
+          <dl class="row">
+            <dt class="col-sm-3 col-lg-2 text-muted">
+              <%= render BlockScoutWeb.CommonComponentsView, "_i_tooltip_2.html",
+                text: gettext("Confidential Compute Result") %>
+              <%= gettext "Confidential Compute Result" %>
+            </dt>
+            <dd class="col-sm-9 col-lg-10">
+              <!-- Textarea -->
+              <div class="tx-raw-confidential-compute-result">
+                <div class="tile tile-muted">
+                  <pre class="pre-scrollable pre-scrollable-shorty pre-wrap mb-0"><code><%= @transaction.confidential_compute_result %></code></pre>
+                </div>
+              </div>
+            </dd>
+          </dl>
+          <dl class="row">
+            <dt class="col-sm-3 col-lg-2 text-muted">
+              <%= render BlockScoutWeb.CommonComponentsView, "_i_tooltip_2.html",
+                text: gettext("Wrapped") %>
+              <%= gettext "Wrapped" %>
+            </dt>
+            <dd class="col-sm-9 col-lg-10">
+              <!-- Textarea -->
+              <div class="tx-raw-wrapped">
+                <div class="tile tile-muted">
+                  <pre class="pre-scrollable pre-scrollable-shorty pre-wrap mb-0" style="height: 400px;"><code><%= Enum.map_join(@transaction.wrapped, "\n", fn {key, value} -> "#{key}: #{value}" end)  %></code></pre>
+                </div>
+              </div>
+            </dd>
+          </dl>
           <% end %>
         </div>
       </div>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -3686,3 +3686,15 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Yul"
 msgstr ""
+
+#: lib/block_scout_web/templates/transaction/overview.html.eex:527
+#: lib/block_scout_web/templates/transaction/overview.html.eex:528
+#, elixir-autogen, elixir-format
+msgid "Confidential Compute Result"
+msgstr ""
+
+#: lib/block_scout_web/templates/transaction/overview.html.eex:542
+#: lib/block_scout_web/templates/transaction/overview.html.eex:543
+#, elixir-autogen, elixir-format
+msgid "Wrapped"
+msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -3686,3 +3686,15 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Yul"
 msgstr ""
+
+#: lib/block_scout_web/templates/transaction/overview.html.eex:527
+#: lib/block_scout_web/templates/transaction/overview.html.eex:528
+#, elixir-autogen, elixir-format
+msgid "Confidential Compute Result"
+msgstr ""
+
+#: lib/block_scout_web/templates/transaction/overview.html.eex:542
+#: lib/block_scout_web/templates/transaction/overview.html.eex:543
+#, elixir-autogen, elixir-format
+msgid "Wrapped"
+msgstr ""

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transaction.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transaction.ex
@@ -66,7 +66,9 @@ defmodule EthereumJSONRPC.Transaction do
           transaction_index: non_neg_integer(),
           max_priority_fee_per_gas: non_neg_integer(),
           max_fee_per_gas: non_neg_integer(),
-          type: non_neg_integer()
+          type: non_neg_integer(),
+          wrapped: map() | nil,
+          confidential_compute_result: binary() | nil
         }
 
   @doc """
@@ -105,7 +107,9 @@ defmodule EthereumJSONRPC.Transaction do
         to_address_hash: "0x5df9b87991262f6ba471f09758cde1c0fc1de734",
         v: 28,
         value: 31337,
-        transaction_index: 0
+        transaction_index: 0,
+        confidential_compute_result: nil,
+        wrapped: nil
       }
 
   Erigon `elixir` from txpool_content method can be converted to `params`.
@@ -148,7 +152,9 @@ defmodule EthereumJSONRPC.Transaction do
         transaction_index: nil,
         type: 2,
         v: 0,
-        value: 275000000000000000
+        value: 275000000000000000,
+        confidential_compute_result: nil,
+        wrapped: nil
       }
   """
   @spec elixir_to_params(elixir) :: params
@@ -192,7 +198,9 @@ defmodule EthereumJSONRPC.Transaction do
       transaction_index: index,
       type: type,
       max_priority_fee_per_gas: max_priority_fee_per_gas,
-      max_fee_per_gas: max_fee_per_gas
+      max_fee_per_gas: max_fee_per_gas,
+      wrapped: transaction["wrapped"],
+      confidential_compute_result: transaction["confidentialComputeResult"]
     }
 
     if transaction["creates"] do
@@ -242,7 +250,9 @@ defmodule EthereumJSONRPC.Transaction do
       transaction_index: index,
       type: type,
       max_priority_fee_per_gas: max_priority_fee_per_gas,
-      max_fee_per_gas: max_fee_per_gas
+      max_fee_per_gas: max_fee_per_gas,
+      wrapped: transaction["wrapped"],
+      confidential_compute_result: transaction["confidentialComputeResult"]
     }
 
     if transaction["creates"] do
@@ -287,7 +297,9 @@ defmodule EthereumJSONRPC.Transaction do
       v: v,
       value: value,
       transaction_index: index,
-      type: type
+      type: type,
+      wrapped: transaction["wrapped"],
+      confidential_compute_result: transaction["confidentialComputeResult"]
     }
 
     if transaction["creates"] do
@@ -330,7 +342,9 @@ defmodule EthereumJSONRPC.Transaction do
       to_address_hash: to_address_hash,
       v: v,
       value: value,
-      transaction_index: index
+      transaction_index: index,
+      wrapped: transaction["wrapped"],
+      confidential_compute_result: transaction["confidentialComputeResult"]
     }
 
     if transaction["creates"] do
@@ -446,7 +460,7 @@ defmodule EthereumJSONRPC.Transaction do
   #
   # "txType": to avoid FunctionClauseError when indexing Wanchain
   defp entry_to_elixir({key, value})
-       when key in ~w(blockHash condition creates from hash input jsonrpc publicKey raw to txType),
+       when key in ~w(blockHash condition creates from hash input jsonrpc publicKey raw to txType wrapped confidentialComputeResult),
        do: {key, value}
 
   # specific to Nethermind client

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transactions.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transactions.ex
@@ -57,7 +57,9 @@ defmodule EthereumJSONRPC.Transactions do
           v: "0xbd",
           value: 0,
           transaction_index: 0,
-          created_contract_address_hash: "0xffc87239eb0267bc3ca2cd51d12fbf278e02ccb4"
+          created_contract_address_hash: "0xffc87239eb0267bc3ca2cd51d12fbf278e02ccb4",
+          confidential_compute_result: nil,
+          wrapped: nil
         }
       ]
 

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -34,7 +34,7 @@ defmodule Explorer.Chain.Transaction do
   alias Explorer.SmartContract.SigProviderInterface
 
   @optional_attrs ~w(max_priority_fee_per_gas max_fee_per_gas block_hash block_number created_contract_address_hash cumulative_gas_used earliest_processing_start
-                     error gas_price gas_used index created_contract_code_indexed_at status to_address_hash revert_reason type has_error_in_internal_txs)a
+                     error gas_price gas_used index created_contract_code_indexed_at status to_address_hash revert_reason type has_error_in_internal_txs wrapped confidential_compute_result)a
 
   @required_attrs ~w(from_address_hash gas hash input nonce r s v value)a
 
@@ -174,7 +174,9 @@ defmodule Explorer.Chain.Transaction do
           max_priority_fee_per_gas: wei_per_gas | nil,
           max_fee_per_gas: wei_per_gas | nil,
           type: non_neg_integer() | nil,
-          has_error_in_internal_txs: boolean()
+          has_error_in_internal_txs: boolean(),
+          confidential_compute_result: binary() | nil,
+          wrapped: binary() | nil
         }
 
   @derive {Poison.Encoder,
@@ -246,6 +248,9 @@ defmodule Explorer.Chain.Transaction do
     # Used to force refetch of a block in case a transaction is re-collated
     # in a different block. See: https://github.com/blockscout/blockscout/issues/1911
     field(:old_block_hash, Hash.Full)
+
+    field(:confidential_compute_result, :binary)
+    field(:wrapped, :map)
 
     timestamps()
 

--- a/apps/explorer/priv/repo/migrations/20230923121205_add_suave_fields.exs
+++ b/apps/explorer/priv/repo/migrations/20230923121205_add_suave_fields.exs
@@ -1,0 +1,11 @@
+defmodule Explorer.Repo.Migrations.AddSuaveFields do
+  @moduledoc false
+  use Ecto.Migration
+
+  def change do
+    alter table(:transactions) do
+      add(:confidential_compute_result, :binary)
+      add(:wrapped, :jsonb)
+    end
+  end
+end

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitwalker/alpine-elixir-phoenix:1.14 AS builder
+FROM hexpm/elixir:1.14.5-erlang-25.3.2.6-alpine-3.18.2 AS builder
 
 WORKDIR /app
 
@@ -18,6 +18,11 @@ ARG MIXPANEL_TOKEN
 ARG MIXPANEL_URL
 ARG AMPLITUDE_API_KEY
 ARG AMPLITUDE_URL
+
+# custom ERL_FLAGS are passed for (public) multi-platform builds
+# to fix qemu segfault, more info: https://github.com/erlang/otp/pull/6340
+ARG ERL_FLAGS
+ENV ERL_FLAGS=$ERL_FLAGS
 
 # Cache elixir deps
 ADD mix.exs mix.lock ./
@@ -55,7 +60,7 @@ RUN mkdir -p /opt/release \
   && mv _build/${MIX_ENV}/rel/blockscout /opt/release
 
 ##############################################################
-FROM bitwalker/alpine-elixir-phoenix:1.14
+FROM hexpm/elixir:1.14.5-erlang-25.3.2.6-alpine-3.18.2
 
 ARG RELEASE_VERSION
 ENV RELEASE_VERSION=${RELEASE_VERSION}


### PR DESCRIPTION
## Motivation

Build a multi-arch docker image and integrate some change of the suave-geth client, namely `wrapped` and `confidentialComputeResult` fields for a transaction.

## Changelog

### Enhancements

- Make the docker image really multi arch
- Add new suave-geth fields

### Bug Fixes
N/A

### Incompatible Changes
N/A

## Upgrading
N/A

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
